### PR TITLE
Only act on log events from Enjin loggers

### DIFF
--- a/bukkit/src/main/java/com/enjin/bukkit/util/LogFilter.java
+++ b/bukkit/src/main/java/com/enjin/bukkit/util/LogFilter.java
@@ -18,11 +18,13 @@ public class LogFilter extends AbstractFilter {
 
     @Override
     public Result filter(LogEvent event) {
+        if (!event.getLoggerName().startsWith("com.enjin")) return Result.NEUTRAL;
+
         String message = event.getMessage().getFormattedMessage().trim().toLowerCase();
         if (!debug && message.startsWith("[debug]")) {
             return Result.DENY;
         } else {
-            return Result.ACCEPT;
+            return Result.NEUTRAL;
         }
     }
 


### PR DESCRIPTION
As it stands, this log filter will block message events from every logger. This change makes it only interact with messages from Enjin-based loggers.